### PR TITLE
KWR*->KWH in chapter 12.

### DIFF
--- a/src/Chapter-12.md
+++ b/src/Chapter-12.md
@@ -82,11 +82,11 @@ This illustrates how messy the English language can be and how designing a theor
 
 ### y sound without the letter y
 
-If you encounter a word that has the "y" sound, only use `KWR*` if it is spelled with a "y". If it isn't spelled with a "y" don't use any left hand consonant chord.
+If you encounter a word that has the "y" sound, only use `KWH` if it is spelled with a "y". If it isn't spelled with a "y" don't use any left hand consonant chord.
 
 #### Examples
-* yes `KWR*ES`
-* yep `KWR*EP`
+* yes `KWHES`
+* yep `KWHEP`
 * use `AOUS`
 * usual `AOURB/WAL`
   - There aren't, unfortunately, a lot of single stroke words to demonstrate this


### PR DESCRIPTION
Also the text immediately below says to use "AOURB/WAL" for usual. But on my current version of the lapwing dictionary, AOURB by itself yields 'usual'. AOURB/WAL does also give usual, I guess.