### PR TITLE
Fix incorrect mappings

### DIFF
--- a/src/practice/10-right-ch-sh-rch.txt
+++ b/src/practice/10-right-ch-sh-rch.txt
@@ -182,4 +182,3 @@ nauseous	TPHAURBS
 cautious	KAURBS
 precious	PRERBS
 luscious	HRURBS
-

--- a/src/practice/10-right-n-j-lj.txt
+++ b/src/practice/10-right-n-j-lj.txt
@@ -115,7 +115,7 @@ ton	TOPB
 tin	TEUPB
 ten	TEPB
 tun	TUPB
-yawn	KWRA*UPB
+yawn	KWHAUPB
 queen	KWAOEPB
 quin	KWEUPB
 clean	KHRAOEPB

--- a/src/practice/10-test.txt
+++ b/src/practice/10-test.txt
@@ -293,7 +293,7 @@ ton	TOPB
 tin	TEUPB
 ten	TEPB
 tun	TUPB
-yawn	KWRA*UPB
+yawn	KWHAUPB
 queen	KWAOEPB
 quin	KWEUPB
 clean	KHRAOEPB

--- a/src/practice/11-right-BL-BLT.txt
+++ b/src/practice/11-right-BL-BLT.txt
@@ -7,7 +7,7 @@ viable	SRAOEUBL
 viewable	SRAOUBL
 seeable	SAOEBL
 global	TKPWHROEBL
-gable	TKPWAEUBLs
+gable	TKPWAEUBL
 gabble	TKPWABL
 gobble	TKPWOBL
 dryable	TKRAOEUBL

--- a/src/practice/11-right-BL-BLT.txt
+++ b/src/practice/11-right-BL-BLT.txt
@@ -61,4 +61,3 @@ provability	PRAOUFBLT
 possibility	POFBLT
 livability	HREUFBLT
 ability	ABLT
-

--- a/src/practice/11-right-shus-and-shal.txt
+++ b/src/practice/11-right-shus-and-shal.txt
@@ -18,4 +18,3 @@ fascial	TPARBL
 crucial	KRAOURBL
 casual	KARBL
 racial	RAEURBL
-

--- a/src/practice/11-test.txt
+++ b/src/practice/11-test.txt
@@ -158,4 +158,3 @@ provability	PRAOUFBLT
 possibility	POFBLT
 livability	HREUFBLT
 ability	ABLT
-

--- a/src/practice/12-words-with-f-as-s.txt
+++ b/src/practice/12-words-with-f-as-s.txt
@@ -116,4 +116,3 @@ blossom	PWHROFPL
 bosom	PWOFPL
 plasm	PHRAFPL
 prism	PREUFPL
-

--- a/src/practice/13-ar-or-er.txt
+++ b/src/practice/13-ar-or-er.txt
@@ -2,7 +2,7 @@ sellar	SEL/A*R
 cellar	KREL/A*R
 bulbar	PWUL/-B/A*R
 beggar	PWEG/A*R
-planar	PHRAEPB/A*R
+planar	PHRAEUPB/A*R
 lunar	HRAOUPB/A*R
 hangar	HAPBG/A*R
 vendor	SREPBD/O*R

--- a/src/practice/13-test.txt
+++ b/src/practice/13-test.txt
@@ -2,7 +2,7 @@ sellar	SEL/A*R
 cellar	KREL/A*R
 bulbar	PWUL/-B/A*R
 beggar	PWEG/A*R
-planar	PHRAEPB/A*R
+planar	PHRAEUPB/A*R
 lunar	HRAOUPB/A*R
 hangar	HAPBG/A*R
 vendor	SREPBD/O*R

--- a/src/practice/17-left-clusters.txt
+++ b/src/practice/17-left-clusters.txt
@@ -16,7 +16,7 @@ comprise	KPRAOEUS
 compartment	KPARPLT
 compass	KPAS
 compete	KPAOET
-extrapolate	KPRA/PO/HRAEUGT
+extrapolate	KPRA/PO/HRAEUT
 community	KPHAOUPB/TEU
 commodity	KPHOD/TEU
 compare	KPAEUR
@@ -44,7 +44,7 @@ interaction	SPWRABGS
 intoxicate	SPWOBGS/KAEUT
 intensity	SPWEPBS/TEU
 intention	SPWEPBGS
-intentional	SPWEPBGLS
+intentional	SPWEPBLGS
 enthrall	SPWRAUL
 enter	SPWER
 entropy	SPWROEP

--- a/src/practice/5-basic-left-hand.txt
+++ b/src/practice/5-basic-left-hand.txt
@@ -85,4 +85,3 @@ shrub	SHRUB
 throb	THROB
 threat	THRET
 thread	THRED
-

--- a/src/practice/8-AOE.txt
+++ b/src/practice/8-AOE.txt
@@ -133,4 +133,3 @@ eep	AOEP
 eel	AOEL
 eat	AOET
 ease	AOES
-

--- a/src/practice/8-AOEU.txt
+++ b/src/practice/8-AOEU.txt
@@ -1,5 +1,5 @@
 snide	STPHAOEUD
-snipe	STPAOEUP
+snipe	STPHAOEUP
 strife	STRAOEUF
 stripe	STRAOEUP
 stride	STRAOEUD


### PR DESCRIPTION
There are still several incorrect mappings that were not addressed. I did not sort them this time so that you don't need to look at the individual commits to get a clean diff.

If you want to sort them, here is a script to automatically do so: https://github.com/spencer3035/lapwing-for-beginners/blob/helper-scripts/clean_practice.sh

There are 6 incorrect mappings (really 3 unique ones repearted in two different files) that are not addressed because I wasn't sure the best mapping to choose according to the training.

In files

- https://github.com/aerickt/lapwing-for-beginners/blob/main/src/practice/17-folding.txt
- https://github.com/aerickt/lapwing-for-beginners/blob/main/src/practice/17-e-folding.txt

The mappings 

- "ceremony SER/KWRE/PHOEPB" should be one of 
    - SER/PHOE/TPHEU
    - SER/PHOEPB
- "patrimony PAT/REU/PHOEPB" should be one of
    -  PA/TREU/PHOE/TPHEU
    -  PA/TREU/PHOEPB
    -  PA/TREU/PHOEPB/KWREU
    -  PART/PHOE/TPHEU
    -  PART/PHOEPB
- "secretary SE/KRE/TAER" should be one of 
    - SERBG/TAER
    -  SEBG/RE/TAEUR/KWREU
    -  SEBG/RE/TAER

If you let me know which mappings are desired, I can address them and push another commit with the changes.