### PR TITLE
feat: support external links again with `mdbook-external-links2`

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -34,6 +34,8 @@ jobs:
           rustup update
           cargo install --version ${MDBOOK_VERSION} mdbook
           # Install plugins if necessary
+          # https://github.com/avivace/mdbook-external-links:
+          cargo install --version 0.2.0 mdbook-external-links2
 
       - name: Build with mdBook
         run: mdbook build

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 > This is only for contributors!
 
-Install `mdbook` and the [external links preprocessor](https://crates.io/crates/mdbook-external-links).
+Install `mdbook` and the [external links preprocessor](https://crates.io/crates/mdbook-external-links2).
 
 ```
-cargo install mdbook mdbook-external-links
+cargo install mdbook mdbook-external-links2
 ```
 
 In the root folder, build with:

--- a/book.toml
+++ b/book.toml
@@ -11,6 +11,5 @@ additional-css = ["theme/pagetoc.css", "theme/custom.css"]
 additional-js = ["theme/pagetoc.js", "theme/steno-viz.js"]
 sidebar-header-nav = false # prefer pagetoc on the right side
 
-# TODO: support this plugin again
-# https://github.com/jonahgoldwastaken/mdbook-external-links
-# [preprocessor.external-links]
+# https://github.com/avivace/mdbook-external-links
+[preprocessor.external-links2]

--- a/book.toml
+++ b/book.toml
@@ -13,3 +13,4 @@ sidebar-header-nav = false # prefer pagetoc on the right side
 
 # https://github.com/avivace/mdbook-external-links
 [preprocessor.external-links2]
+optional = true


### PR DESCRIPTION
## Background

I once dropped the [`mdbook-external-links`](https://github.com/jonahgoldwastaken/mdbook-external-links) plugin to support mdBook v5. I sent a PR to the upstream repository, but it's been open for three months.

Recently, someone (@avivace) published [a fork](https://github.com/avivace/mdbook-external-links) that contains my fix as `mdbook-external-links2`, and I think it's OK to migrate to it.

## Changes

Use that fork (`mdbook-external-links2`) in CI.

I marked it `optional`. If you don't have a copy of it, you can still build the `mdbook` with internal links. This is just my preference for smooth development.

## Tests

- [x] I tested the CI work on my fork.
- [x] External links are opened in new tabs.

CC. @field-chicken, because you preferred external links.