### PR TITLE
Correct some practice txts

### DIFF
--- a/src/practice/16-briefs.txt
+++ b/src/practice/16-briefs.txt
@@ -1,5 +1,5 @@
 is	S
-sentence	 STEPBS
+sentence	STEPBS
 ask	SK
 and	SKP
 have	SR

--- a/src/practice/5-EU.txt
+++ b/src/practice/5-EU.txt
@@ -19,7 +19,6 @@ chip	KHEUP
 chill	KHEUL
 chit	KHEUT
 krill	KREUL
-sieve	SEUF
 sir	SEUR
 sip	SEUP
 sill	SEUL

--- a/src/practice/5-basic-left-hand.txt
+++ b/src/practice/5-basic-left-hand.txt
@@ -35,7 +35,6 @@ shall	SHAL
 shag	SHAG
 shat	SHAT
 shad	SHAD
-shove	SHOF
 shore	SHOR
 shop	SHOP
 shot	SHOT

--- a/src/practice/5-dbl.txt
+++ b/src/practice/5-dbl.txt
@@ -2,7 +2,6 @@ dap	TKAP
 dab	TKAB
 dat	TKAT
 dad	TKAD
-dove	TKOF
 doll	TKOL
 dog	TKOG
 dot	TKOT
@@ -74,7 +73,6 @@ lab	HRAB
 lag	HRAG
 lass	HRAS
 lad	HRAD
-love	HROF
 lore	HROR
 lop	HROP
 lob	HROB
@@ -82,7 +80,6 @@ lol	HROL
 log	HROG
 lot	HROT
 loss	HROS
-live	HREUF
 lip	HREUP
 lib	HREUB
 lit	HREUT

--- a/src/practice/5-test.txt
+++ b/src/practice/5-test.txt
@@ -19,7 +19,6 @@ chip	KHEUP
 chill	KHEUL
 chit	KHEUT
 krill	KREUL
-sieve	SEUF
 sir	SEUR
 sip	SEUP
 sill	SEUL
@@ -57,7 +56,6 @@ dap	TKAP
 dab	TKAB
 dat	TKAT
 dad	TKAD
-dove	TKOF
 doll	TKOL
 dog	TKOG
 dot	TKOT
@@ -129,7 +127,6 @@ lab	HRAB
 lag	HRAG
 lass	HRAS
 lad	HRAD
-love	HROF
 lore	HROR
 lop	HROP
 lob	HROB
@@ -137,7 +134,6 @@ lol	HROL
 log	HROG
 lot	HROT
 loss	HROS
-live	HREUF
 lip	HREUP
 lib	HREUB
 lit	HREUT
@@ -188,7 +184,6 @@ shall	SHAL
 shag	SHAG
 shat	SHAT
 shad	SHAD
-shove	SHOF
 shore	SHOR
 shop	SHOP
 shot	SHOT

--- a/src/practice/6-gny.txt
+++ b/src/practice/6-gny.txt
@@ -9,7 +9,6 @@ gore	TKPWOR
 gob	TKPWOB
 got	TKPWOT
 god	TKPWOD
-give	TKPWEUF
 gill	TKPWEUL
 gig	TKPWEUG
 git	TKPWEUT

--- a/src/practice/6-test.txt
+++ b/src/practice/6-test.txt
@@ -9,7 +9,6 @@ gore	TKPWOR
 gob	TKPWOB
 got	TKPWOT
 god	TKPWOD
-give	TKPWEUF
 gill	TKPWEUL
 gig	TKPWEUG
 git	TKPWEUT

--- a/src/practice/7-OE-OU-OEU.txt
+++ b/src/practice/7-OE-OU-OEU.txt
@@ -23,7 +23,6 @@ vowel	SROUL
 soap	SOEP
 sour	SOUR
 globe	TKPWHROEB
-grove	TKPWROEF
 grouse	TKPWROUS
 goal	TKPWOEL
 goad	TKPWOED

--- a/src/practice/7-test.txt
+++ b/src/practice/7-test.txt
@@ -208,7 +208,6 @@ vowel	SROUL
 soap	SOEP
 sour	SOUR
 globe	TKPWHROEB
-grove	TKPWROEF
 grouse	TKPWROUS
 goal	TKPWOEL
 goad	TKPWOED

--- a/src/practice/8-AOE.txt
+++ b/src/practice/8-AOE.txt
@@ -70,7 +70,6 @@ teal	TAOEL
 teat	TAOET
 queer	KWAOER
 quease	KWAOES
-cleave	KHRAOEF
 clear	KHRAOER
 cleat	KHRAOET
 chief	KHAOEF
@@ -127,7 +126,6 @@ reap	RAOEP
 reel	RAOEL
 rete	RAOET
 reed	RAOED
-eve	AOEF
 ear	AOER
 eep	AOEP
 eel	AOEL

--- a/src/practice/8-AOEU.txt
+++ b/src/practice/8-AOEU.txt
@@ -29,7 +29,6 @@ size	SAOEUZ
 glide	TKPWHRAOEUD
 gripe	TKPWRAOEUP
 guide	TKPWAOEUD
-drive	TKRAOEUF
 dryer	TKRAOEUR
 dire	TKAOEUR
 dial	TKAOEUL
@@ -40,7 +39,6 @@ night	TPHAOEUT
 nice	TPHAOEUS
 fright	TPRAOEUT
 fried	TPRAOEUD
-five	TPAOEUF
 fire	TPAOEUR
 file	TPAOEUL
 fight	TPAOEUT
@@ -58,7 +56,6 @@ tight	TAOEUT
 tide	TAOEUD
 choir	KWAOEUR
 quite	KWAOEUT
-chive	KHAOEUF
 chide	KHAOEUD
 cried	KRAOEUD
 kite	KAOEUT

--- a/src/practice/8-AU.txt
+++ b/src/practice/8-AU.txt
@@ -6,7 +6,6 @@ squad	SKWAUD
 scrawl	SKRAUL
 small	SPHAUL
 sprawl	SPRAUL
-suave	SWAUF
 swap	SWAUP
 swab	SWAUB
 swat	SWAUT

--- a/src/practice/8-test.txt
+++ b/src/practice/8-test.txt
@@ -209,7 +209,6 @@ vowel	SROUL
 soap	SOEP
 sour	SOUR
 globe	TKPWHROEB
-grove	TKPWROEF
 grouse	TKPWROUS
 goal	TKPWOEL
 goad	TKPWOED
@@ -408,7 +407,6 @@ teal	TAOEL
 teat	TAOET
 queer	KWAOER
 quease	KWAOES
-cleave	KHRAOEF
 clear	KHRAOER
 cleat	KHRAOET
 chief	KHAOEF
@@ -465,7 +463,6 @@ reap	RAOEP
 reel	RAOEL
 rete	RAOET
 reed	RAOED
-eve	AOEF
 ear	AOER
 eep	AOEP
 eel	AOEL
@@ -502,7 +499,6 @@ size	SAOEUZ
 glide	TKPWHRAOEUD
 gripe	TKPWRAOEUP
 guide	TKPWAOEUD
-drive	TKRAOEUF
 dryer	TKRAOEUR
 dire	TKAOEUR
 dial	TKAOEUL
@@ -513,7 +509,6 @@ night	TPHAOEUT
 nice	TPHAOEUS
 fright	TPRAOEUT
 fried	TPRAOEUD
-five	TPAOEUF
 fire	TPAOEUR
 file	TPAOEUL
 fight	TPAOEUT
@@ -531,7 +526,6 @@ tight	TAOEUT
 tide	TAOEUD
 choir	KWAOEUR
 quite	KWAOEUT
-chive	KHAOEUF
 chide	KHAOEUD
 cried	KRAOEUD
 kite	KAOEUT
@@ -662,7 +656,6 @@ squad	SKWAUD
 scrawl	SKRAUL
 small	SPHAUL
 sprawl	SPRAUL
-suave	SWAUF
 swap	SWAUP
 swab	SWAUB
 swat	SWAUT


### PR DESCRIPTION
Some entries in the chapter 5-8 tests used -F as "v", which is only taught in chapter 9. I removed these. If I missed any, do let me know.

Important to mention, this PR also corrects the 5-EU.txt practice, which doesn't seem to be used. This should either be removed or implemented into chapter 5.